### PR TITLE
Add support for styling the branch infobar

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -435,7 +435,7 @@ table.files td.icon {
     color: #ccc;
 }
 
-.commit-tease {
+.commit-tease, .branch-infobar {
     color: #8485ce;
     background-color: #364952;
     border-color: #4c85a0;


### PR DESCRIPTION
#### What's the issue:
Branch infobar wasn't getting styling treatment.


#### What's fixed:
Now it is :-)

#### Screenshots:
Before: 
![before](https://cloud.githubusercontent.com/assets/894251/21207269/d99cac2e-c22c-11e6-967b-6782e919ae94.png)

After:
![after](https://cloud.githubusercontent.com/assets/894251/21207276/e04bd860-c22c-11e6-84ba-6166fdeb32e0.png)
