### PR TITLE
Fix the message color which is shown after branch merged was colored black

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1085,6 +1085,10 @@ timeline-comment::before {
     border-top: solid 1px #304251;
 }
 
+.merge-branch-heading {
+  color: #fff;
+}
+
 .branch-action-state-merged .branch-action-body {
     border-color: #6e5494;
 }


### PR DESCRIPTION
#### What's the issue:

If you are a owner of a repository, you can see a message "Pull request successfully merged and closed" after PR merged. It was colored black and hard to read.

#### What's fixed:

Make it `#fff` like other headline as.

#### Screenshots:
<!-- Some screenshots before/after will help me merge pull request faster -->

before:
![2017-03-22 12 04 30](https://cloud.githubusercontent.com/assets/1428294/24180366/e3dd3e48-0ef7-11e7-8531-16c563ebda26.png)

after:
![2017-03-22 12 02 50](https://cloud.githubusercontent.com/assets/1428294/24180361/e1d0dc90-0ef7-11e7-9b55-6a703462e699.png)

<!-- Appreciate your help :) -->