### PR TITLE
Repository settings page has white boxes + buttons

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1547,6 +1547,19 @@ hr,
     border-color: #df3e3e;
 }
 
+.Box {
+    background-color: #1a2632;
+    border: 1px solid #1a2632;
+}
+
+.btn:disabled, .btn.disabled {
+    color: white;
+    background-color: #1a2632;
+    background-image: none;
+    border-color: rgb(42, 58, 72);
+    box-shadow: none;
+}
+
 .integrations-callout-standalone .integration-settings-callout {
     border-color: #304251;
 }


### PR DESCRIPTION
#### What's the issue:
The repository settings page contains white boxes and buttons that make the text difficult to read. 


#### What's fixed:
Modified the .css to increase the legibility of the text. 


#### Screenshots:

BEFORE: 

![image](https://user-images.githubusercontent.com/33237549/32202110-d3cee534-bdb0-11e7-9dc0-668839bd5f5f.png)

AFTER: 

![image](https://user-images.githubusercontent.com/33237549/32202122-f2262ce0-bdb0-11e7-9bcd-a9eb30fc099d.png)


<!-- Appreciate your help :) -->