### PR TITLE
Fixes text color of issue renaming

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -2165,6 +2165,9 @@ li.session-device {
     filter: invert(1);
 }
 
+.discussion-item .renamed-was, .discussion-item .renamed-is {
+    color: #fff;
+}
 
 /* End */
 

--- a/github-dark.css
+++ b/github-dark.css
@@ -2166,7 +2166,7 @@ li.session-device {
 }
 
 .discussion-item .renamed-was, .discussion-item .renamed-is {
-    color: #fff;
+    color: #607d8b;
 }
 
 /* End */


### PR DESCRIPTION
Fixes text color of issue renaming

#### What's the issue:
A renamed issue has a discussion item showing the old and new issue title. Unfortunately the text is dark on a dark background:

![before](https://user-images.githubusercontent.com/478564/33651585-ae1c3aa8-da66-11e7-86a6-776fd29f02f8.png)

#### What's fixed:
This PR change the text color to white so that it looks like this:

![after](https://user-images.githubusercontent.com/478564/33651594-bd7cd6ce-da66-11e7-9684-f1c43b560053.png)