### PR TITLE
Change branch-name background and text color for Browse Activity tab

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1161,7 +1161,8 @@ a.Box-row-link.h4.js-navigation-open {
 }
 
 a.branch-name {
-    color: inherit;
+    color: #151f29;
+    background-color: #627790;
 }
 
 .table-of-contents li+li {


### PR DESCRIPTION
The old style showed a bright box with white text for branch names on the index page. This replaces this with the style that is used for code highlights in Markdown

Before:
![bildschirmfoto 2018-02-01 um 09 39 10](https://user-images.githubusercontent.com/522537/35669015-00e07b7e-0734-11e8-843a-9d2598405224.png)

After:
![bildschirmfoto 2018-02-01 um 09 39 55](https://user-images.githubusercontent.com/522537/35669020-05c8df46-0734-11e8-8b81-1c5c2604359f.png)
