### PR TITLE
Update Project Columns

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1373,6 +1373,14 @@ ul.comparison-list>li {
     background-color: #1a2632 !important;
 }
 
+.js-project-column-cards {
+    -ms-overflow-style: none;
+    overflow: -moz-scrollbars-none;
+}
+
+.js-project-column-cards::-webkit-scrollbar {
+    display: none;
+}
 
 /* Repo Pulse Tab */
 

--- a/github-dark.css
+++ b/github-dark.css
@@ -1361,6 +1361,10 @@ ul.comparison-list>li {
     background-color: #1a2632;
 }
 
+.project-column {
+    background-color: #151f29;
+}
+
 .bg-white {
     background-color: #243447 !important;
 }

--- a/github-dark.css
+++ b/github-dark.css
@@ -1375,7 +1375,6 @@ ul.comparison-list>li {
 
 .js-project-column-cards {
     -ms-overflow-style: none;
-    overflow: -moz-scrollbars-none;
 }
 
 .js-project-column-cards::-webkit-scrollbar {


### PR DESCRIPTION
#### What's the issue:
GitHub recently made a change to the columns on their Projects tab, which resulted in only the columns being light themed, while the rest of the page remained dark.
Additionally, a scroll bar on the side of each column is displayed in the dark theme that is not shown in the standard GitHub theme. The scrollbar is particularly jarring when hovered over, as it turns very light grey. 


#### What's fixed:
The project columns are now correctly styled to match the dark theme and the scroll bar on project columns has been hidden, to match the standard Github theme.


#### Screenshots:
**Column Background**
Before:
![image](https://user-images.githubusercontent.com/10774982/35881148-bf44443e-0b34-11e8-9fa7-6a07b7cd568a.png)

After:
![image](https://user-images.githubusercontent.com/10774982/35881289-38148cac-0b35-11e8-8324-b5b488f6d4f1.png)

**Scrollbar**
Before:
![image](https://user-images.githubusercontent.com/10774982/35881316-4a0eda20-0b35-11e8-894a-44b68880129a.png)

After:
![image](https://user-images.githubusercontent.com/10774982/35881430-9b9d7cac-0b35-11e8-81db-76b1c411c337.png)