### PR TITLE
Tone down notification list border color

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1651,6 +1651,14 @@ hr,
 
 /* Notification */
 
+.list-group-item {
+    border-color: #304251;
+}
+
+.notifications-list .confirmation+.list-group-item {
+    border-top-color: #304251;
+}
+
 .list-group-item.navigation-focus {
     background-color: #151f29;
 }


### PR DESCRIPTION
#### What's the issue:
On the notifications tab, the borders between each notification were very light grey, rather than the regular border color.


#### What's fixed:
The border color was changed to #304251, to match other borders.


#### Screenshots:
Before:
![image](https://user-images.githubusercontent.com/10774982/35883459-249ea836-0b3c-11e8-9bd7-66ad848bdbf2.png)


After:
![image](https://user-images.githubusercontent.com/10774982/35883440-10148ae8-0b3c-11e8-9907-b702f3094f48.png)
