### PR TITLE
Fix security page

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1821,8 +1821,8 @@ dl.new-email-form {
 
 /* Settings | Security */
 
-li.session-device.session-current,
-li.session-device {
+.session-device.session-current,
+.session-device {
     background-color: #1a2632;
 }
 
@@ -2202,7 +2202,7 @@ li.session-device {
 
 .markdown-body .task-list-item.hovered {
   background: #424a7e !important;
-
+}
 .discussion-item .renamed-was, .discussion-item .renamed-is {
     color: #607d8b;
 }
@@ -2422,7 +2422,4 @@ li.session-device {
 }
 .cm-tag {
     color: #63a35c !important;
-}
-.cm-variable-3 {
- 	color:
 }


### PR DESCRIPTION
#### What's the issue:
The current session `<div>` on the [security](https://github.com/settings/security) page is too bright.

#### What's fixed:
I made `.session-device.session-current` have the proper background.
I also removed duplicate `.cm-variable-3` and added the necessary closing brace for `.markdown-body .task-list-item.hovered`.


#### Screenshots:

Before:
![screen shot 2018-03-05 at 3 38 48 pm](https://user-images.githubusercontent.com/24863887/36995779-63422a40-208b-11e8-8552-ee2ff8fca28b.png)

After:
![screen shot 2018-03-05 at 3 43 37 pm](https://user-images.githubusercontent.com/24863887/36996029-1db72218-208c-11e8-929f-d9f972b8f76e.png)

Related: #44 