### PR TITLE
Fix wiki history border

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1351,6 +1351,10 @@ ul.comparison-list>li {
     border-color: var(--border-color);
 }
 
+.boxed-group-table td {
+    border-color: var(--border-color);
+}
+
 /* Repo Project Tab */
 
 .border {


### PR DESCRIPTION
#### What's the issue:
Horrible white border on wiki revision history


#### What's fixed:
Border is now the `border-color` CSS variable.


#### Screenshots:
<!-- Some screenshots before/after will help me merge pull request faster -->
Before:
![historyfixbefore](https://user-images.githubusercontent.com/24863887/43026865-e097fc30-8c4d-11e8-8956-a8d74159aba3.PNG)
After:
![historyfixafter](https://user-images.githubusercontent.com/24863887/43026872-eaa4d086-8c4d-11e8-9a16-bd06e8d0e692.PNG)

You can see this here: https://github.com/seanysean/github-dark/wiki/_history

One more thing: I'm planning on sending some more pull requests, so should I update `github-dark.user.css` as well in them?
<!-- Appreciate your help :) -->