### PR TITLE
Fix repo file finder

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1351,6 +1351,10 @@ ul.comparison-list>li {
     border-color: var(--border-color);
 }
 
+.boxed-group-table td {
+    border-color: var(--border-color);
+}
+
 /* Repo Project Tab */
 
 .border {

--- a/github-dark.css
+++ b/github-dark.css
@@ -529,6 +529,20 @@ span.d-block {
     border-color: var(--border-color);
 }
 
+/* Repo find file */
+
+.tree-finder .tree-browser,
+.tree-browser td {
+    border-color: var(--border-color) !important;
+}
+.tree-browser td {
+    background: var(--background-color);
+}
+.tree-browser tr[aria-selected="true"] td,
+.tree-browser tr.navigation-focus td {
+    background: var(--depth-color);
+}
+
 /* Repo Blame */
 
 .blame-commit-title,

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -537,6 +537,20 @@
         background-color: var(--accent-color);
         border-color: var(--border-color);
     }
+    
+    /* Repo find file */
+    
+    .tree-finder .tree-browser,
+    .tree-browser td {
+        border-color: var(--border-color) !important;
+    }
+    .tree-browser td {
+        background: var(--background-color);
+    }
+    .tree-browser tr[aria-selected="true"] td,
+    .tree-browser tr.navigation-focus td {
+        background: var(--depth-color);
+    }
 
     /* Repo Blame */
 
@@ -1357,6 +1371,10 @@
     }
 
     .wiki-wrapper .wiki-custom-sidebar {
+        border-color: var(--border-color);
+    }
+    
+    .boxed-group-table td {
         border-color: var(--border-color);
     }
 


### PR DESCRIPTION
#### What's the issue:
Lots of white elements on [repo find file](https://github.com/cquanu/github-dark/find/master).

#### What's fixed:
Changed them to proper color. I also updated `github-dark.user.css` with #62 code.

#### Screenshots:
<!-- Some screenshots before/after will help me merge pull request faster -->
Before:
![fixfindfilebefore](https://user-images.githubusercontent.com/24863887/43359095-4a815ae4-9273-11e8-8db7-6b160813cae4.PNG)
After:
![fixfindfileafter](https://user-images.githubusercontent.com/24863887/43359097-4ddff222-9273-11e8-87d6-d5d231769d0d.PNG)

**Note:** It [looks like](https://github.com/cquanu/github-dark/pull/63/files#diff-64ae9f3acdf5e1c48548adca960457b1R1368) I re-added the code from the **fix wiki history** PR in `github-dark.css`, but I just intended to update my branch. It might be a bug.
<!-- Appreciate your help :) -->