### PR TITLE
Fix repo collaborators page

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1609,6 +1609,16 @@ hr,
     border-color: var(--border-color);
 }
 
+/* Repo Settings | Collaborators */
+
+.access-form-wrapper {
+    background-color: var(--depth-color);
+    border-color: var(--border-color);
+}
+.autocomplete-results {
+    background-color: var(--depth-color);
+}
+
 /* Profile */
 
 .border-top {

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -1613,7 +1613,17 @@
     .integrations-callout-standalone .integration-settings-callout {
         border-color: var(--border-color);
     }
+    
+    /* Repo Settings | Collaborators */
 
+    .access-form-wrapper {
+        background-color: var(--depth-color);
+        border-color: var(--border-color);
+    }
+    .autocomplete-results {
+        background-color: var(--depth-color);
+    }
+    
     /* Profile */
 
     .border-top {


### PR DESCRIPTION
#### What's the issue:
<!-- Describe the issue -->
Bright elements on repo collaborator page.

#### What's fixed:
<!-- Describe the changes proposed in this pull request -->
Gives the bright elements the proper colors.

#### Screenshots:
<!-- Some screenshots before/after will help me merge pull request faster -->
Before:
![screen shot 2018-10-01 at 1 07 01 pm](https://user-images.githubusercontent.com/24863887/46300996-789cee80-c57b-11e8-93ed-4aa55908a79b.png)
After:
![screen shot 2018-10-01 at 1 08 33 pm](https://user-images.githubusercontent.com/24863887/46301017-8488b080-c57b-11e8-9578-5d68d86e98c7.png)

<!-- Appreciate your help :) -->