### PR TITLE
Fix Watch dropdown open state color

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -177,7 +177,8 @@ h4 {
 
 .btn:active,
 .btn.selected,
-.btn.zeroclipboard-is-active {
+.btn.zeroclipboard-is-active,
+[open] > .btn {
     background-color: var(--body-color);
     background-image: none;
     border-color: var(--border-color);


### PR DESCRIPTION
#### What's the issue:
Watch has an open state that wasn't covered when you hover over the dropdown that opens up.

#### What's fixed:
Added a line to cover that state in a rule that seemed most appropriate.


#### Screenshots:
Hover on dropdown menu items:

Before:
![screenshot from 2018-10-31 18-21-02](https://user-images.githubusercontent.com/11252825/47828327-d02ba700-dd3f-11e8-9904-cd5910f5419c.png)

After:
![screenshot from 2018-10-31 18-38-45](https://user-images.githubusercontent.com/11252825/47828355-f5201a00-dd3f-11e8-9fd7-a87676daccc4.png)
