### PR TITLE
Fix new user popup colors

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -90,6 +90,12 @@ h4 {
     border-color: var(--border-color);
 }
 
+.js-notice {
+    background-image: none;
+    background-color: var(--body-color);
+    border-color: var(--border-color);
+}
+
 /* Main Site Login */
 
 .session-authentication {


### PR DESCRIPTION
#### What's the issue:
New users get a popup suggesting they fill out their profile. It was not styled yet.


#### What's fixed:
Added styling rules to the place that seemed reasonable.


#### Screenshots:
Before:
![screenshot from 2018-10-31 19-19-43](https://user-images.githubusercontent.com/11252825/47829309-fe12ea80-dd43-11e8-9c5c-585bf5403f94.png)

After:
![screenshot from 2018-10-31 19-24-52](https://user-images.githubusercontent.com/11252825/47829310-02d79e80-dd44-11e8-9e86-645f835c0cbc.png)
