### PR TITLE
Fix dark text in selected cell in Watch dropdown

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -861,6 +861,11 @@ span.d-block {
     border-color: var(--border-color);
 }
 
+.select-menu-item[aria-checked="true"] .select-menu-item-heading,
+.select-menu-item[aria-checked="true"] svg {
+    color: var(--primary-text-color) !important;
+}
+
 /* Repo | Pull Request Tab */
 
 .border-left,


### PR DESCRIPTION
#### What's the issue:
Dark heading text in a selected cell under Watch dropdown.


#### What's fixed:
Made the heading and the checkmark white to stand out and highlight that this item is selected. Was a little conflicted on not including the description text, but I think this looks better.


#### Screenshots:
Before:
![screenshot from 2018-10-31 19-39-30](https://user-images.githubusercontent.com/11252825/47830412-fe61b480-dd48-11e8-98b0-b91c37192a60.png)

After:
![screenshot from 2018-10-31 19-56-54](https://user-images.githubusercontent.com/11252825/47830429-06215900-dd49-11e8-98c1-be4388fc1e05.png)
