### PR TITLE
Changed GitHub Jobs logo color

### DIFF
--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -338,6 +338,10 @@
         border-top: 1px solid var(--border-color);
     }
 
+    .github-jobs-logo strong {
+        filter: invert(40%);   
+    }
+    
     /* New Repo */
 
     .outline-box-highlighted {


### PR DESCRIPTION
#### What's the issue:
GitHub Jobs logo was black so with a dark background, there was a low contrast


#### What's fixed:
Changed the color to a light gray


#### Screenshots:
![before-after-github-dark-github-jobs](https://user-images.githubusercontent.com/22895992/62416977-e35c0200-b644-11e9-9ded-64cfbe730b54.png)
