### PR TITLE
Patch 1

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -337,6 +337,10 @@ button.dropdown-item.dropdown-signout {
     border-top: 1px solid var(--border-color);
 }
 
+.github-jobs-logo strong {
+    filter: invert(40%);   
+}
+
 /* New Repo */
 
 .outline-box-highlighted {

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -338,6 +338,10 @@
         border-top: 1px solid var(--border-color);
     }
 
+    .github-jobs-logo strong {
+        filter: invert(40%);   
+    }
+    
     /* New Repo */
 
     .outline-box-highlighted {


### PR DESCRIPTION
#### What's the issue:
Yesterday I updated GitHub Jobs logo color in github-dark.user.css so github-dark.css lacks the update

#### What's fixed:
Updated github-dark.css with the new color


#### Screenshots:
![before-after-github-dark-github-jobs](https://user-images.githubusercontent.com/22895992/62416977-e35c0200-b644-11e9-9ded-64cfbe730b54.png)