### PR TITLE
Last commit card header has a white background

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1461,6 +1461,10 @@ mark {
     background-color: var(--body-color) !important;
 }
 
+.bg-blue-light {
+    background-color: var(--accent-color) !important;
+}
+
 .js-project-column-cards {
     -ms-overflow-style: none;
 }

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -1462,6 +1462,10 @@
         background-color: var(--body-color) !important;
     }
 
+    .bg-blue-light {
+        backgroud-color: var(--accent-color) !important;
+    }
+
     .js-project-column-cards {
         -ms-overflow-style: none;
     }


### PR DESCRIPTION
#### What's the issue:
The card's header has a white background.

#### What's fixed:
Now the background-color is --acccent-color.

#### Screenshots:
![image](https://user-images.githubusercontent.com/22895992/62576015-47c4ce80-b89c-11e9-98f3-0bd0a7b30bd7.png)

