### PR TITLE
Changed Markdown images' background color to transparent

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -613,7 +613,7 @@ span.d-block {
 }
 
 .markdown-body img {
-    background-color: var(--depth-color);
+    background-color: transparent;
 }
 
 .markdown-body h1 .octicon-link,

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -614,7 +614,7 @@
     }
 
     .markdown-body img {
-        background-color: var(--depth-color);
+        background-color: transparent;
     }
 
     .markdown-body h1 .octicon-link,


### PR DESCRIPTION
#### What's the issue:
Markdown images have a background-color so transparent images appear with a darker background than the page itself.

#### What's fixed:
Markdown images' background is now transparent

#### Screenshots:
![image](https://user-images.githubusercontent.com/22895992/62577721-cff8a300-b89f-11e9-9d26-04dea64015eb.png)