### PR TITLE
Changed Project Issue blur color from white to --accent-color

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1453,6 +1453,10 @@ mark {
     background-color: #151f29;
 }
 
+.project-issue-body-blur {
+    background: linear-gradient(0deg, var(--accent-color), hsla(0, 0%, 100%, 0));
+}
+
 .bg-white {
     background-color: var(--accent-color) !important;
 }

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -1454,6 +1454,10 @@
         background-color: #151f29;
     }
 
+    .project-issue-body-blur {
+        background: linear-gradient(0deg, var(--accent-color), hsla(0, 0%, 100%, 0));
+    }
+ 
     .bg-white {
         background-color: var(--accent-color) !important;
     }


### PR DESCRIPTION
#### What's the issue:
On the Project page, when you click on an issue, if the issue is too long to be displayed a white blur is displayed at its bottom.


#### What's fixed:
It now has the right color


#### Screenshots:
![image](https://user-images.githubusercontent.com/22895992/62725080-b9c02380-ba14-11e9-95db-a85cd5f31baf.png)
