### PR TITLE
Fix read notifications

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -1844,7 +1844,7 @@ hr,
 }
 
 .notifications .list-group-item.read {
-    background-color: var(--accent-color);
+    background-color: var(--depth-color);
 }
     
 .notifications .read .list-group-item-name>a {

--- a/github-dark.css
+++ b/github-dark.css
@@ -1843,6 +1843,14 @@ hr,
     border-top: 1px solid var(--border-color);
 }
 
+.notifications .list-group-item.read {
+    background-color: var(--accent-color);
+}
+    
+.notifications .read .list-group-item-name>a {
+    color: #999;
+}
+
 /* Organisation */
 
 .org-name {

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -1843,6 +1843,13 @@
         border-top: 1px solid var(--border-color);
     }
 
+    .notifications .list-group-item.read {
+        background-color: var(--accent-color);
+    }
+    .notifications .read .list-group-item-name>a {
+        color: #999;
+    }
+    
     /* Organisation */
 
     .org-name {

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -1844,7 +1844,7 @@
     }
 
     .notifications .list-group-item.read {
-        background-color: var(--accent-color);
+        background-color: var(--depth-color);
     }
     .notifications .read .list-group-item-name>a {
         color: #999;


### PR DESCRIPTION
#### What's the issue:
<!-- Describe the issue -->
When clicking on a notification or viewing read notifications (https://github.com/notifications/read), they appear bright.

#### What's fixed:
<!-- Describe the changes proposed in this pull request --> 
Fixes the above issue by changing the background of the notification items to be darker. I used `#999` for the text color because `secondary-text-color` was too dark.

#### Screenshots:
<!-- Some screenshots before/after will help me merge pull request faster -->
Before:
![image](https://user-images.githubusercontent.com/24863887/67041799-d3f53c80-f0fc-11e9-8a9d-f054bf49863e.png)
After:
![image](https://user-images.githubusercontent.com/24863887/67041846-ec655700-f0fc-11e9-8416-b4b71fbde5e9.png)

<!-- Appreciate your help :) -->