### PR TITLE
Fix light background on branch selection drop down

### DIFF
--- a/github-dark.css
+++ b/github-dark.css
@@ -904,6 +904,43 @@ span.d-block {
     color: var(--primary-text-color) !important;
 }
 
+.SelectMenu-filter {
+    border-top: 1px solid var(--border-color);
+}
+
+.SelectMenu-item {
+    background-color: var(--accent-color);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.SelectMenu-item[aria-checked=true] {
+    color: var(--primary-text-color);
+}
+
+.SelectMenu-item[aria-checked=true]:hover {
+    background-color: var(--body-color) !important;
+}
+
+.SelectMenu-list {
+    background-color: var(--border-color);
+    border-top: 1px solid var(--border-color);
+}
+
+.SelectMenu-modal {
+    background-color: var(--body-color);
+    border: 1px solid var(--border-color);
+}
+
+.SelectMenu-tab {
+    box-shadow: inset 0 -1px 0 var(--border-color);
+}
+
+.SelectMenu-tab[aria-selected=true] {
+    background-color: var(--accent-color);
+    border-color: var(--border-color);
+    color: var(--primary-text-color);
+}
+
 /* Repo | Pull Request Tab */
 
 .border-left,

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -904,6 +904,43 @@
         color: var(--primary-text-color) !important;
     }
 
+    .SelectMenu-filter {
+        border-top: 1px solid var(--border-color);
+    }
+    
+    .SelectMenu-item {
+        background-color: var(--accent-color);
+        border-bottom: 1px solid var(--border-color);
+    }
+    
+    .SelectMenu-item[aria-checked=true] {
+        color: var(--primary-text-color);
+    }
+    
+    .SelectMenu-item[aria-checked=true]:hover {
+        background-color: var(--body-color) !important;
+    }
+    
+    .SelectMenu-list {
+        background-color: var(--border-color);
+        border-top: 1px solid var(--border-color);
+    }
+    
+    .SelectMenu-modal {
+        background-color: var(--body-color);
+        border: 1px solid var(--border-color);
+    }
+    
+    .SelectMenu-tab {
+        box-shadow: inset 0 -1px 0 var(--border-color);
+    }
+    
+    .SelectMenu-tab[aria-selected=true] {
+        background-color: var(--accent-color);
+        border-color: var(--border-color);
+        color: var(--primary-text-color);
+    }
+
     /* Repo | Pull Request Tab */
 
     .border-left,

--- a/github-dark.user.css
+++ b/github-dark.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           GitHub Dark v2.6.3
 @namespace      github.com/cquanu/github-dark
-@version        2.6.22
+@version        2.6.23
 @description    GitHub Dark 2.0
 @author         Quan You, Tyler Thrailkill, Lance Jordan, Lexa Hall, Jared Allard, seanysean
 @license        MIT


### PR DESCRIPTION
#### What's the issue:
Branch selection drop down menu has a light background.

#### What's fixed:
Added dark background to the drop down modal and list items.  Fixed borders and dark text.

#### Screenshots:
Current:
![image](https://user-images.githubusercontent.com/1945223/74123380-da1b9700-4b8b-11ea-9452-a65aa057cae4.png)

PR:
![image](https://user-images.githubusercontent.com/1945223/74123387-dd168780-4b8b-11ea-9d2b-1e93c0ac21ba.png)
